### PR TITLE
I believe this is the HDOP value

### DIFF
--- a/src/main/java/net/studioblueplanet/ttbin/Activity.java
+++ b/src/main/java/net/studioblueplanet/ttbin/Activity.java
@@ -613,7 +613,7 @@ public class Activity
         //  0 1 byte
         //  1 uint16   EVPE in cm? sensor 1 or GPS error in cm??
         //  3 uint16   EHPE in cm? filtered (?) sensor 1. GPS signal strength?
-        //  5 uint8    derived data from sensor 1?? =6 most of the time
+        //  5 uint8    HDOP (https://en.wikipedia.org/wiki/Dilution_of_precision_(navigation)#Meaning_of_DOP_Values)
         //  6 uint8[4] sensors 2-5
         // 10 uint8[4] sensors 6-10
         // 14 uint8[4] sensors 2-5 normalized [0, 1]


### PR DESCRIPTION
I've been doing some disassembling, and saw that this value is likely the HDOP, when looking at the symbols their linux tool has:

```
000000000017b1d4 R protobuf::gps::LocationAccuracy::kEHPEFieldNumber
000000000017b1d0 R protobuf::gps::LocationAccuracy::kEVPEFieldNumber
000000000017b1cc R protobuf::gps::LocationAccuracy::kHDOPFieldNumber
00000000003d6ca0 B protobuf::gps::LocationAccuracy::default_instance_
000000000017b1c4 R protobuf::gps::LocationAccuracy::kNavTypeFieldNumber
000000000011ff50 T protobuf::gps::LocationAccuracy::InitAsDefaultInstance()
000000000011f720 T protobuf::gps::LocationAccuracy::MergePartialFromCodedStream(google::protobuf::io::CodedInputStream*)
000000000017b1c8 R protobuf::gps::LocationAccuracy::kActiveSatellitesFieldNumber
00000000001210f0 T protobuf::gps::LocationAccuracy::Swap(protobuf::gps::LocationAccuracy*)
```

Another one, is perhaps the ActiveSatellites, but I don't know which one (yet).